### PR TITLE
ci: make release automation resilient to GITHUB_TOKEN limits

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -2,6 +2,11 @@ name: Release Please
 
 # Conventional-commit driven versioning. Opens/maintains a release PR on main;
 # merging it creates the git tag + GitHub release, which triggers release.yaml.
+#
+# Set a RELEASE_PLEASE_TOKEN secret (PAT with contents+pull-requests write) for
+# full automation: it lets the release PR run CI and lets the created tag trigger
+# release.yaml. Without it, the default GITHUB_TOKEN is used and those downstream
+# workflows must be run manually.
 on:
   push:
     branches:
@@ -20,4 +25,4 @@ jobs:
       name: Release Please
       uses: googleapis/release-please-action@v4
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,20 @@ name: Release
 
 # Triggered by the version tag that release-please creates. Builds and pushes
 # the multi-arch image and the Helm chart to GHCR using the built-in token.
+#
+# NOTE: tags pushed by release-please using the default GITHUB_TOKEN do not
+# trigger this workflow (GitHub blocks recursive workflow triggers). For full
+# automation, give release-please a PAT (RELEASE_PLEASE_TOKEN). The
+# workflow_dispatch trigger below allows publishing a tag manually meanwhile.
 on:
   push:
     tags:
     - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to publish (e.g. v2.0.0)
+        required: true
 
 permissions:
   contents: read
@@ -21,6 +31,7 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+        ref: ${{ inputs.tag || github.ref }}
     -
       name: Setup Bazel
       uses: bazel-contrib/setup-bazel@0.19.0
@@ -34,7 +45,9 @@ jobs:
     -
       name: Resolve version
       id: version
-      run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      env:
+        REF: ${{ inputs.tag || github.ref_name }}
+      run: echo "value=${REF#v}" >> "$GITHUB_OUTPUT"
     -
       name: Registry login (GHCR)
       run: |


### PR DESCRIPTION
## Problem

Tags created by release-please with the default `GITHUB_TOKEN` do **not** trigger downstream workflows (GitHub blocks recursive triggers). So after merging the release PR, the `v2.0.0` tag was created but `Release` (GHCR publish) never ran. The same limitation means release PRs don't get CI checks (require admin-merge).

## Changes

- **release-please** uses `${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}` — add a `RELEASE_PLEASE_TOKEN` PAT (contents + pull-requests write) for full automation; otherwise behaves as before.
- **release.yaml** gains `workflow_dispatch` (with a `tag` input) so a tag can be published manually when no PAT is configured. The checkout/version steps honor the dispatched tag.

## Follow-up (manual, by maintainer)

- To publish the already-created **v2.0.0**: run the `Release` workflow via *Actions → Release → Run workflow* with `tag = v2.0.0` (after this merges).
- For hands-off releases going forward: create the `RELEASE_PLEASE_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)