### PR TITLE
chore: bump googleapis/release-please-action to v5

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,6 +23,6 @@ jobs:
     steps:
     -
       name: Release Please
-      uses: googleapis/release-please-action@v4
+      uses: googleapis/release-please-action@v5
       with:
         token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps `googleapis/release-please-action` from v4 to v5 (latest, v5.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)