### PR TITLE
fix: publish per-platform manifests for multi-arch image (#16)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,14 +50,56 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     -
-      name: Push image (skip if tag already exists)
+      name: Push image (skip only if the multi-arch index is complete)
+      # A bare `docker manifest inspect` on the index tag is not enough: a
+      # multi-arch push can land the index while leaving its per-platform child
+      # manifests unpublished, so the index resolves but every platform digest
+      # 404s on pull (issue #16). We treat the tag as present only when the
+      # index AND all child manifests resolve, and we verify the same after
+      # pushing so an incomplete index fails the build instead of shipping.
       env:
         IMAGE_COMMIT_SHA: ${{ steps.img.outputs.sha }}
+        GH_ACTOR: ${{ github.actor }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if docker manifest inspect "${IMAGE_REPO}:${IMAGE_COMMIT_SHA}" >/dev/null 2>&1; then
-          echo "Image ${IMAGE_REPO}:${IMAGE_COMMIT_SHA} already exists — skipping image push."
+        repo="${IMAGE_REPO#ghcr.io/}"
+        acc="application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json"
+
+        # Succeeds only if tag $1 resolves to an index whose every child
+        # manifest also resolves. Retries to tolerate registry propagation.
+        index_complete() {
+          local tag="$1" token idx digests code d ok
+          for _ in 1 2 3 4 5; do
+            token="$(curl -fsSL -u "${GH_ACTOR}:${GH_TOKEN}" \
+              "https://ghcr.io/token?scope=repository:${repo}:pull" | jq -r .token)" || { sleep 5; continue; }
+            idx="$(curl -fsSL -H "Authorization: Bearer ${token}" -H "Accept: ${acc}" \
+              "https://ghcr.io/v2/${repo}/manifests/${tag}")" || { sleep 5; continue; }
+            digests="$(echo "${idx}" | jq -r '.manifests[].digest')"
+            [ -n "${digests}" ] || { sleep 5; continue; }
+            ok=1
+            for d in ${digests}; do
+              code="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${token}" \
+                -H "Accept: ${acc}" "https://ghcr.io/v2/${repo}/manifests/${d}")"
+              if [ "${code}" != "200" ]; then echo "  child ${d} -> ${code}"; ok=0; fi
+            done
+            [ "${ok}" = "1" ] && return 0
+            sleep 5
+          done
+          return 1
+        }
+
+        if index_complete "${IMAGE_COMMIT_SHA}"; then
+          echo "Image ${IMAGE_REPO}:${IMAGE_COMMIT_SHA} already complete — skipping image push."
         else
+          echo "Image ${IMAGE_REPO}:${IMAGE_COMMIT_SHA} missing or incomplete — pushing."
           bazel run //cmd/webhook:push "--//cmd/webhook:version=${IMAGE_COMMIT_SHA}"
+          echo "Verifying every platform manifest resolves…"
+          if index_complete "${IMAGE_COMMIT_SHA}"; then
+            echo "All platform manifests present."
+          else
+            echo "::error::Pushed index ${IMAGE_REPO}:${IMAGE_COMMIT_SHA} is incomplete (a child manifest 404s)."
+            exit 1
+          fi
         fi
     -
       name: Push chart

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -42,10 +42,20 @@ image_from_binary(
 )
 
 # `bazel run //cmd/webhook:push` pushes to GHCR, tagged latest + the app version.
+#
+# `:image` is a multi-platform image_index. `tag_list` only tags the index; its
+# child (per-platform) manifests stay untagged, and an index-only push leaves
+# them dangling on GHCR — the index resolves but each platform digest 404s on
+# pull (see issue #16). `manifest_tags` publishes one tag per child manifest so
+# every platform manifest is explicitly pushed and retained.
 image_push(
     name = "push",
     build_settings = {"VERSION": ":version"},
     image = ":image",
+    manifest_tags = [
+        "latest-{{.os}}-{{.architecture}}{{if .variant}}-{{.variant}}{{end}}",
+        "{{.VERSION}}-{{.os}}-{{.architecture}}{{if .variant}}-{{.variant}}{{end}}",
+    ],
     registry = "ghcr.io",
     repository = "bpalermo/cert-manager-webhook-ns1",
     tag_list = [


### PR DESCRIPTION
Fixes #16.

## Problem

`bazel run //cmd/webhook:push` published the **OCI image index** but the per-platform child manifests it references (`linux/amd64`, `linux/arm64`) were never retained on GHCR. The index resolves and lists both platforms, so `crane manifest <tag>` looks fine — but any actual pull 404s on the platform digest, yielding `ErrImagePull`.

## Root cause

`:image` is a multi-platform `image_index`. `tag_list` only tags the **index**; its child manifests stay **untagged** and an index-only push leaves them dangling on GHCR (the index resolves, the platform digests 404).

This was confirmed against the CI log for `a1bc527`: the GHCR push transferred only `1` blob in <1s (`1 from disk … 0 from container registry`), whereas the same build pushed to a local `registry:2` transferred all `20` blobs and every child resolved — with **identical digests** to the broken GHCR tag. So the image content and build structure are correct; only the index-only publish was at fault.

## Fix

- **`cmd/webhook/BUILD.bazel`** — add `manifest_tags` to `:push`, publishing each child manifest under its own tag (`<tag>-<os>-<arch>[-<variant>]`) so every platform manifest is explicitly pushed and retained. Verified against a local registry: each platform tag resolves to a single-platform manifest and the index children resolve (HTTP 200).
- **`.github/workflows/publish.yaml`**
  - Skip the image push **only when the index AND all child manifests resolve**, so an existing-but-incomplete tag (the currently broken `latest`/SHA) is re-pushed and repaired instead of skipped forever.
  - **Verify every platform manifest resolves after pushing** and fail the build otherwise (with propagation retries), so an index-only push can never ship a broken tag again. Uses curl + the GHCR token — no new tooling.

## Verification

Built and pushed to a throwaway local `registry:2`; the new per-platform tags appear and resolve:

```
test/webhook:dev-linux-amd64        -> application/vnd.oci.image.manifest.v1+json
test/webhook:dev-linux-arm64-v8     -> application/vnd.oci.image.manifest.v1+json
index children -> both HTTP 200
```

Once merged, the publish run will re-push `latest` and the SHA tags and the new verify step will confirm all platform manifests resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)