### PR TITLE
chore: tag images with the full commit SHA, not the short SHA

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,7 @@ jobs:
       name: Compute image commit SHA
       id: img
       run: |
-        sha="$(git log -1 --format=%h -- cmd pkg go.mod go.sum MODULE.bazel MODULE.bazel.lock)"
+        sha="$(git log -1 --format=%H -- cmd pkg go.mod go.sum MODULE.bazel MODULE.bazel.lock)"
         echo "sha=${sha}" >> "$GITHUB_OUTPUT"
         echo "Image version: ${sha}"
     -

--- a/bazel/workspace_status.sh
+++ b/bazel/workspace_status.sh
@@ -2,7 +2,7 @@
 #
 # Emits build stamps consumed by rules_img / rules_helm.
 #
-# STABLE_IMAGE_COMMIT_SHA identifies the app/image version: the short SHA of the
+# STABLE_IMAGE_COMMIT_SHA identifies the app/image version: the full SHA of the
 # last commit that touched any image build input. A chart-only change leaves it
 # unchanged, so the image is not re-tagged. CI sets $IMAGE_COMMIT_SHA (computed
 # once); locally it is derived from git.
@@ -13,9 +13,9 @@ IMAGE_PATHS=(cmd pkg go.mod go.sum MODULE.bazel MODULE.bazel.lock)
 
 image_sha="${IMAGE_COMMIT_SHA:-}"
 if [[ -z "${image_sha}" ]]; then
-  image_sha="$(git log -1 --format=%h -- "${IMAGE_PATHS[@]}" 2>/dev/null || true)"
+  image_sha="$(git log -1 --format=%H -- "${IMAGE_PATHS[@]}" 2>/dev/null || true)"
   [[ -z "${image_sha}" ]] && image_sha="dev"
 fi
 
 echo "STABLE_IMAGE_COMMIT_SHA ${image_sha}"
-echo "STABLE_GIT_SHA $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo "STABLE_GIT_SHA $(git rev-parse HEAD 2>/dev/null || echo unknown)"


### PR DESCRIPTION
Switch the app/image version (`IMAGE_COMMIT_SHA`) from the abbreviated commit SHA to the **full 40-char SHA**.

The short SHA is ambiguous and can collide or lengthen as history grows; the full SHA is stable and unambiguous. This feeds the image tag, the per-platform tags (`<sha>-<os>-<arch>[-<variant>]`), the chart `appVersion`, and the chart `version` (`0.0.0-<sha>`).

## Changes
- `bazel/workspace_status.sh` — `git log --format=%h` → `%H`; drop `--short` from `STABLE_GIT_SHA`.
- `.github/workflows/publish.yaml` — `git log --format=%h` → `%H` when computing the CI image version.

## Verification
- `bazel build //chart --stamp` packages cleanly with `version: 0.0.0-<full-sha>` / `appVersion: <full-sha>` — a valid semver pre-release.
- `//bazel:workspace_status_shellcheck_test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)