### PR TITLE
fix: don't override NS1 endpoint with an empty string (#19)

### DIFF
--- a/pkg/solver/ns1.go
+++ b/pkg/solver/ns1.go
@@ -192,11 +192,16 @@ func (c *Ns1DNSProviderSolver) setNS1Client(ch *v1alpha1.ChallengeRequest, cfg n
 		}
 		httpClient.Transport = tr
 	}
-	c.ns1Client = ns1Rest.NewClient(
-		httpClient,
+	opts := []func(*ns1Rest.Client){
 		ns1Rest.SetAPIKey(apiKey),
-		ns1Rest.SetEndpoint(cfg.Endpoint),
-	)
+	}
+	// Only override the endpoint when one is configured; passing "" to
+	// SetEndpoint clobbers the SDK default (https://api.nsone.net/v1/) with an
+	// empty URL, breaking every request with "unsupported protocol scheme """.
+	if cfg.Endpoint != "" {
+		opts = append(opts, ns1Rest.SetEndpoint(cfg.Endpoint))
+	}
+	c.ns1Client = ns1Rest.NewClient(httpClient, opts...)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #19.

## Problem

With an issuer `config` that omits `endpoint` (the common NS1 SaaS case), every DNS-01 challenge fails:

```
Put "/zones/.../TXT": unsupported protocol scheme ""
```

## Root cause

`setNS1Client` called `ns1Rest.SetEndpoint(cfg.Endpoint)` unconditionally. `endpoint` is optional, so `cfg.Endpoint` is `""`, and the SDK's `SetEndpoint` does `c.Endpoint, _ = url.Parse("")` — clobbering the built-in default `https://api.nsone.net/v1/` with an empty URL. The client then issues requests with no scheme/host.

## Fix

Build the client options and apply `SetEndpoint` only when an endpoint is configured:

```go
opts := []func(*ns1Rest.Client){ns1Rest.SetAPIKey(apiKey)}
if cfg.Endpoint != "" {
    opts = append(opts, ns1Rest.SetEndpoint(cfg.Endpoint))
}
c.ns1Client = ns1Rest.NewClient(httpClient, opts...)
```

This keeps the `endpoint` override working for NS1 Managed / on-prem while restoring the SaaS default when omitted.

`bazel build //pkg/solver //cmd/webhook:webhook` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)